### PR TITLE
Add data-morph-ai exception to config.yaml

### DIFF
--- a/grayskull/pypi/config.yaml
+++ b/grayskull/pypi/config.yaml
@@ -74,6 +74,10 @@ dask:
   conda_forge: dask-core
   import_name: dask
 
+data-morph-ai:
+  conda_forge: data-morph-ai
+  import_name: data_morph
+
 datadotworld:
   conda_forge: datadotworld-py
   import_name: datadotworld


### PR DESCRIPTION
I'm working on publishing to conda and had an issue with the mapping of the distribution name to the package name. Here's the package on PyPI: https://pypi.org/project/data-morph-ai/